### PR TITLE
Add option for custom color shades

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,11 +85,21 @@ const palx = (hex, options = {}) => {
   hues.forEach(h => {
     const c = chroma.hsl(h, sat, lte)
     const key = keyword(c)
+    if (options.replace && options.colors && options.colors.hasOwnProperty(key)) return
     colors.push({
       key,
       value: createShades('' + c.hex())
     })
   })
+
+  if (options.colors) {
+    Object.keys(options.colors).forEach(key => {
+      colors.push({
+        key,
+        value: createShades('' + options.colors[key])
+      })
+    })
+  }
 
   const obj = Object.assign({
     base: hex,

--- a/test/index.js
+++ b/test/index.js
@@ -7,3 +7,22 @@ test('returns a color object', t => {
   t.is(typeof colors, 'object')
 })
 
+test('generates a supplementary color array', t => {
+  const orange = '#ff8000'
+  const colors = palx('#07c', {
+    colors: { orange }
+  })
+  t.is(colors.orange[6], '#dd8d54')
+  t.is(colors.hasOwnProperty('orange2'), true)
+})
+
+test('replaces default colors with user options', t => {
+  const orange = '#ff8000'
+  const colors = palx('#07c', {
+    colors: { orange },
+    replace: true
+  })
+  t.is(colors.orange[6], '#fa7d00')
+  t.is(colors.hasOwnProperty('orange2'), false)
+})
+


### PR DESCRIPTION
Facilitate better control over color generation - specifically when using `axs` or `understyle` packages.

Solves [Improve color generation](https://github.com/jxnblk/axs/issues/14) in the [`axs`](https://github.com/jxnblk/axs) package